### PR TITLE
Fix missing whitespace below section subtitles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../jekyll-theme-ss-nes
   specs:
-    jekyll-theme-ss-nes (1.1.2)
+    jekyll-theme-ss-nes (1.1.3)
       jekyll (>= 3.5, < 5.0)
 
 GEM


### PR DESCRIPTION
This pull request updates the custom Jekyll theme to v1.1.3, which contains a [CSS addition that fixes missing whitespace below section subtitles](https://github.com/SS-NES/jekyll-theme-ss-nes/commit/2fb00a5f2d2448cc21934c5e6e00b3254423c460), for example:

<img width="1997" height="1099" alt="Screenshot 2025-08-08 at 14 02 28" src="https://github.com/user-attachments/assets/a3afbd2f-e530-4380-9c5a-42e662f07429" />

Merging this pull request should automatically build the website using the latest custom Jekyll theme version.